### PR TITLE
Fix opacity scale styles

### DIFF
--- a/src/components/OpacityScale.jsx
+++ b/src/components/OpacityScale.jsx
@@ -3,19 +3,19 @@ import React from 'react';
 const OpacityScale = ({ color, borderRadius = 0, ...props }) => {
     return (
       <article style={{ display: 'flex', gap: '8px', padding: '8px', border: '1px solid', color: color }}>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '100%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '90%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '80%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '70%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '60%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '50%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '40%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '30%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '20%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '10%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '5%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: '2.5%' }}></div>
-      <div style={{ boxshadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '64px', backgroundColor: color, opacity: '1.25%' }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 1 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.9 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.8 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.7 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.6 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.5 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.4 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.3 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.2 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.1 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.05 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '48px', backgroundColor: color, opacity: 0.025 }}></div>
+      <div style={{ boxShadow: 'inset 0 0 0 1px currentColor', width: '100%', minHeight: '64px', backgroundColor: color, opacity: 0.0125 }}></div>
       </article>
     );
 };


### PR DESCRIPTION
## Summary
- correct the `OpacityScale` component styles
  - fix misspelled `boxShadow` property
  - use numeric opacity values

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*