### PR TITLE
Add base-ui Meter, Slider and Tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,9 @@ import CopyCodeSnippet from './components/CopyCodeSnippet.jsx';
 import PatternDisplay from './components/PatternDisplay.jsx';
 import HorizontalBarChart from './components/HorizontalBarChart.jsx';
 import RadarChart from './components/RadarChart.jsx';
+import BaseMeter from './components/Meter.jsx';
+import BaseSlider from './components/Slider.jsx';
+import BaseTabs from './components/Tabs.jsx';
 
 const App = () => {
   const [count, setCount] = useState(0);
@@ -636,6 +639,9 @@ style={{height: '10px', width: '10px', border: 0, display: 'block', padding: 0, 
          
             <InputCheckbox label='Checkbox Label' colorPair={colorPair}/>
             <InputRadioGroup colorPair={colorPair}/>
+            <BaseMeter colorPair={colorPair} value={75} />
+            <BaseSlider colorPair={colorPair} />
+            <BaseTabs colorPair={colorPair} />
 
         <hr style={{ backgroundColor: colorPair[0], borderBottomWidth: '1px', borderBottomStyle: 'solid', borderBottomColor: colorPair[1], borderTopColor: 'transparent', borderLeftColor: 'transparent', borderRightColor: 'transparent',  width: '100%' }}/>
         <Avatar borderRadius={'9999px'} colorPair={colorPair}>AE</Avatar>

--- a/src/components/Meter.jsx
+++ b/src/components/Meter.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Meter } from '@base-ui-components/react/meter';
+
+const BaseMeter = ({ colorPair, value = 50, borderRadius = 0 }) => {
+  const fg = colorPair ? colorPair[1] : 'currentColor';
+  const bg = colorPair ? colorPair[0] : 'transparent';
+  return (
+    <>
+      <style>{`
+        .meter-root {
+          display: inline-flex;
+          flex-direction: column;
+          gap: 4px;
+          color: ${fg};
+        }
+        .meter-track {
+          position: relative;
+          width: 128px;
+          height: 8px;
+          background: ${bg};
+          border: 1px solid ${fg};
+          border-radius: ${borderRadius};
+        }
+        .meter-indicator {
+          display: block;
+          height: 100%;
+          background: ${fg};
+        }
+        .meter-value {
+          font-size: 10px;
+          font-family: monospace;
+        }
+      `}</style>
+      <Meter.Root value={value} className="meter-root">
+        <Meter.Track className="meter-track">
+          <Meter.Indicator className="meter-indicator" />
+        </Meter.Track>
+        <Meter.Value className="meter-value" />
+      </Meter.Root>
+    </>
+  );
+};
+
+export default BaseMeter;

--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Slider } from '@base-ui-components/react/slider';
+
+const BaseSlider = ({ colorPair, defaultValue = 50, borderRadius = 0 }) => {
+  const [val, setVal] = useState(defaultValue);
+  const fg = colorPair ? colorPair[1] : 'currentColor';
+  const bg = colorPair ? colorPair[0] : 'transparent';
+
+  return (
+    <>
+      <style>{`
+        .slider-root {
+          width: 128px;
+          display: inline-flex;
+          align-items: center;
+          color: ${fg};
+        }
+        .slider-track {
+          position: relative;
+          flex: 1;
+          height: 8px;
+          background: ${bg};
+          border: 1px solid ${fg};
+          border-radius: ${borderRadius};
+        }
+        .slider-indicator {
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 100%;
+          background: ${fg};
+        }
+        .slider-thumb {
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background: ${fg};
+          border: 1px solid ${bg};
+        }
+        .slider-value {
+          margin-left: 8px;
+          font-size: 10px;
+          font-family: monospace;
+        }
+      `}</style>
+      <Slider.Root
+        value={val}
+        onValueChange={setVal}
+        className="slider-root"
+        min={0}
+        max={100}
+        step={1}
+      >
+        <Slider.Control className="slider-track">
+          <Slider.Indicator className="slider-indicator" />
+          <Slider.Thumb className="slider-thumb" />
+        </Slider.Control>
+        <Slider.Value className="slider-value" />
+      </Slider.Root>
+    </>
+  );
+};
+
+export default BaseSlider;

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Tabs } from '@base-ui-components/react/tabs';
+
+const BaseTabs = ({ colorPair, borderRadius = 0 }) => {
+  const fg = colorPair ? colorPair[1] : 'currentColor';
+  const bg = colorPair ? colorPair[0] : 'transparent';
+  const [value, setValue] = React.useState(0);
+  return (
+    <>
+      <style>{`
+        .tabs-root {
+          color: ${fg};
+        }
+        .tabs-list {
+          display: flex;
+          gap: 4px;
+          border-bottom: 1px solid ${fg};
+        }
+        .tabs-tab {
+          all: unset;
+          padding: 4px 8px;
+          cursor: pointer;
+          font-size: 12px;
+          border: 1px solid ${fg};
+          background: ${bg};
+          border-radius: ${borderRadius} ${borderRadius} 0 0;
+        }
+        .tabs-tab[data-selected] {
+          background: ${fg};
+          color: ${bg};
+        }
+        .tabs-panel {
+          padding: 8px;
+          border: 1px solid ${fg};
+          border-radius: 0 0 ${borderRadius} ${borderRadius};
+          background: ${bg};
+          font-size: 12px;
+        }
+      `}</style>
+      <Tabs.Root value={value} onValueChange={setValue} className="tabs-root">
+        <Tabs.List className="tabs-list">
+          <Tabs.Tab value={0} className="tabs-tab">One</Tabs.Tab>
+          <Tabs.Tab value={1} className="tabs-tab">Two</Tabs.Tab>
+          <Tabs.Tab value={2} className="tabs-tab">Three</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value={0} className="tabs-panel">First panel</Tabs.Panel>
+        <Tabs.Panel value={1} className="tabs-panel">Second panel</Tabs.Panel>
+        <Tabs.Panel value={2} className="tabs-panel">Third panel</Tabs.Panel>
+      </Tabs.Root>
+    </>
+  );
+};
+
+export default BaseTabs;


### PR DESCRIPTION
## Summary
- integrate base-ui Meter, Slider and Tabs components
- show new components in the sample UI

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
